### PR TITLE
Support new Spotify version (1.0.1)

### DIFF
--- a/Spaytify/Info.plist
+++ b/Spaytify/Info.plist
@@ -29,8 +29,6 @@
     <dict>
       <key>BundleIdentifier</key>
       <string>com.spotify.client</string>
-      <key>MinBundleVersion</key>
-      <string>91400013</string>
     </dict>
   </array>
 </dict>


### PR DESCRIPTION
Apparently, Spotify changed their versioning schema. Spaytify only
patches OS X-methods, so no changes needed there.

Removing MinBundleVersion altogether (instead of changing it) keeps
compatibility with old versions.